### PR TITLE
Draft: failing test that state is wrong for previously resolved promise

### DIFF
--- a/tests/unit/utils/stateful-promise-test.js
+++ b/tests/unit/utils/stateful-promise-test.js
@@ -56,6 +56,26 @@ module('Unit | Utility | stateful-promise', function () {
     assert.false(result.isError);
   });
 
+  test('it provides correct state for unrelated resolved promise', async function (assert) {
+    const resolvedPromise = Promise.resolve(2);
+    const obj = {};
+
+    // promise is resolved _before_ constructing a StatefulPromise
+    // instance for it
+    await resolvedPromise;
+
+    let result = new StatefulPromise().create(obj, resolvedPromise);
+    assert.true(result.isRunning);
+    assert.false(result.isResolved);
+    assert.false(result.isError);
+
+    await Promise.resolve();
+
+    assert.false(result.isRunning);
+    assert.true(result.isResolved);
+    assert.false(result.isError);
+  });
+
   test('it works with primitive', async function (assert) {
     const obj = {};
     let result = new StatefulPromise().create(obj, 2);

--- a/tests/unit/utils/stateful-promise-test.js
+++ b/tests/unit/utils/stateful-promise-test.js
@@ -45,6 +45,12 @@ module('Unit | Utility | stateful-promise', function () {
     await resolvedPromise;
 
     let result = new StatefulPromise().create(obj, resolvedPromise);
+    assert.true(result.isRunning);
+    assert.false(result.isResolved);
+    assert.false(result.isError);
+
+    await result;
+
     assert.false(result.isRunning);
     assert.true(result.isResolved);
     assert.false(result.isError);

--- a/tests/unit/utils/stateful-promise-test.js
+++ b/tests/unit/utils/stateful-promise-test.js
@@ -36,6 +36,20 @@ module('Unit | Utility | stateful-promise', function () {
     assert.false(result.isError);
   });
 
+  test('it provides correct state for previously resolved promise', async function (assert) {
+    const resolvedPromise = Promise.resolve(2);
+    const obj = {};
+
+    // promise is resolved _before_ constructing a StatefulPromise
+    // instance for it
+    await resolvedPromise;
+
+    let result = new StatefulPromise().create(obj, resolvedPromise);
+    assert.false(result.isRunning);
+    assert.true(result.isResolved);
+    assert.false(result.isError);
+  })
+
   test('it works with primitive', async function (assert) {
     const obj = {};
     let result = new StatefulPromise().create(obj, 2);

--- a/tests/unit/utils/stateful-promise-test.js
+++ b/tests/unit/utils/stateful-promise-test.js
@@ -48,7 +48,7 @@ module('Unit | Utility | stateful-promise', function () {
     assert.false(result.isRunning);
     assert.true(result.isResolved);
     assert.false(result.isError);
-  })
+  });
 
   test('it works with primitive', async function (assert) {
     const obj = {};


### PR DESCRIPTION
This test demonstrate that the state is reported wrongly as `isRunning` until next tick if the promise has been resolved _before_ constructing the `StatefulPromise` instance.

As far as I know this issue is by design as the state of a Promise can not be derived synchronously.